### PR TITLE
Closes #198 forward let..in reference

### DIFF
--- a/src/ExExpression.elm
+++ b/src/ExExpression.elm
@@ -104,6 +104,7 @@ elixirControlFlow c e =
 
         Let variables expression ->
             variables
+                |> ExVariable.organizeLetInVariablesOrder
                 |> (flip List.foldl ( c, "" ) <|
                         \( var, exp ) ( cAcc, codeAcc ) ->
                             (case applicationToList var of

--- a/src/ExStatement.elm
+++ b/src/ExStatement.elm
@@ -310,7 +310,7 @@ elixirComment c content =
             if c.hasModuleDoc then
                 { c | lastDoc = Just content } => ""
             else
-                elixirDoc c ModuleDoc content c.mod
+                elixirDoc c ModuleDoc c.mod content
 
         Ex content ->
             (,) c <|

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -1,13 +1,15 @@
 port module Main exposing (..)
 
+import Test
 import Tests
+import UnitTests
 import Test.Runner.Node exposing (run, TestProgram)
 import Json.Encode exposing (Value)
 
 
 main : TestProgram
 main =
-    run emit Tests.all
+    run emit (Test.describe "Elchemy" [ Tests.all, UnitTests.all ])
 
 
 port emit : ( String, Value ) -> Cmd msg

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -455,6 +455,42 @@ a _ = 10
         ]
 
 
+letIns : Test
+letIns =
+    describe "Let in constructs"
+        [ test "Allows to reffer variables in reversed order" <|
+            \() -> """
+            test = let
+              a = b
+              b = 2
+            in a
+            """ |> has "b = 2a = b"
+        , test "More advanced order" <|
+            \() -> """
+              test = let
+                a = b
+                b = 2
+                c = a
+                d = a + c
+              in d
+                """ |> has "b = 2a = bc = ad = (a + c)"
+        , test "Functions work too" <|
+            \() -> """
+              test = let
+                a = \\() -> b
+                b = 10
+              in d
+                """ |> has "b = 10a = fn {} -> b end"
+        , test "Doesn't mind shadowing" <|
+            \() -> """
+              test = let
+                a = \\b -> b
+                b = 10
+              in d
+                """ |> has "a = fn b -> b endb = 10"
+        ]
+
+
 all : Test
 all =
     describe "All"
@@ -471,4 +507,5 @@ all =
         , typeConstructors
         , doctests
         , fileImports
+        , letIns
         ]

--- a/tests/UnitTests.elm
+++ b/tests/UnitTests.elm
@@ -1,0 +1,13 @@
+module UnitTests exposing (..)
+
+import Test exposing (..)
+import Expect
+
+
+all : Test
+all =
+    describe "Test"
+        [ test "Test truth" <|
+            \() ->
+                Expect.equal "a" "a"
+        ]


### PR DESCRIPTION
Fixes #198 by sorting the variables in a right order.
Doesn't fix an edge case of two or more functions calling each other recursively inside a let..in expression ( #220 )