### PR TITLE
Closes #188 - Add new, init, clean, and version to usage message

### DIFF
--- a/elchemy
+++ b/elchemy
@@ -113,7 +113,27 @@ case "$1" in
 
         ;;
     *)
-        echo $"Usage: $0 compile [input_dir] [output_dir] [--unsafe]"
+        echo $"Usage: $0 <COMMAND> [<ARGS>]"
+        cat <<EOF
+
+Available commands include:
+
+    new <PROJECT_NAME>
+        Start a new project
+
+    init
+        Add Elchemy to an existing project
+
+    compile [INPUT_DIR] [OUTPUT_DIR] [--unsafe]
+        Compile Elchemy source code
+
+    clean
+        Remove temporary files
+
+    version
+        Print Elchmey's version number number and exit
+
+EOF
         exit 1
 
 esac


### PR DESCRIPTION
This commit expands the usage message in the `elchemy` Bash script to include brief descriptions of the `new`, `init`, `clean`, and `version` commands, as required by #188.

I'm happy to change the wording if something else would be more appropriate.