### PR TITLE
Closes #260 - Access macros (updateIn, putIn, getIn)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ elchemy_ex/lib/*
 elchemy-*.ez
 _build/
 docs/
+example/
+stable/

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ compile-std-watch:
 	find elchemy-core -name "*.elm" | grep -v ".#" | grep -v "elm-stuff" | entr make compile-std
 
 compile-std-tests-watch:
-	find elchemy-core \( -name "*.elm" -or -name '*.ex' \) | grep -v "elchemy.ex" | grep -v ".#" | grep -v "elm-stuff" | entr bash -c "make compile && make compile-std && make test-std"
+	find elchemy-core \( -name "*.elm" -or -name '*.ex*' \) | grep -v "elchemy.ex" | grep -v ".#" | grep -v "elm-stuff" | entr bash -c "make compile && make compile-std && make test-std"
 
 tests-watch:
 	find . -name "*.elm" | grep -v ".#" | grep -v "elm-stuff" | entr ./node_modules/.bin/elm-test

--- a/src/ExSelector.elm
+++ b/src/ExSelector.elm
@@ -1,0 +1,96 @@
+module ExSelector exposing (Selector(..), maybeAccessMacro, AccessMacro(..), AccessMacroType(..))
+
+import Ast.Expression exposing (Expression(AccessFunction, Application, Variable))
+import Regex
+import Char
+import List.Extra
+import Helpers
+
+
+type Selector
+    = Access String
+
+
+type AccessMacroType
+    = Get
+    | Put
+    | Update
+
+
+type AccessMacro
+    = AccessMacro AccessMacroType Int (List Selector)
+
+
+getSelector : Expression -> Selector
+getSelector expression =
+    case expression of
+        AccessFunction name ->
+            Access (Helpers.toSnakeCase True name)
+
+        _ ->
+            Debug.crash "The only allowed selectors are: .field"
+
+
+maybeAccessMacro : Expression -> List Expression -> Maybe ( AccessMacro, List Expression )
+maybeAccessMacro call args =
+    let
+        accessMacroArgs arity args =
+            case compare (List.length args) arity of
+                LT ->
+                    Debug.crash <|
+                        "Access macros [updateIn/getIn/putIn] cannot be partially applied. Expecting "
+                            ++ toString arity
+                            ++ " selector arguments."
+
+                EQ ->
+                    ( List.map getSelector args, [] )
+
+                GT ->
+                    List.Extra.splitAt arity args
+                        |> Tuple.mapFirst (List.map getSelector)
+    in
+        case ( call, args ) of
+            ( Variable [ name ], args ) ->
+                accessMacroType name
+                    |> Maybe.map
+                        (\( t, arity ) ->
+                            let
+                                ( selectors, rest ) =
+                                    accessMacroArgs arity args
+                            in
+                                ( AccessMacro t arity selectors, rest )
+                        )
+
+            _ ->
+                Nothing
+
+
+accessMacroType : String -> Maybe ( AccessMacroType, Int )
+accessMacroType string =
+    let
+        getArity =
+            String.filter Char.isDigit
+                >> String.toInt
+                >> Result.withDefault 1
+
+        getType x =
+            [ ( "updateIn\\d?", Update )
+            , ( "putIn\\d?", Put )
+            , ( "getIn\\d?", Get )
+            ]
+                |> List.foldl
+                    (\( match, res ) acc ->
+                        case acc of
+                            Nothing ->
+                                if Regex.contains (Regex.regex match) x then
+                                    Just res
+                                else
+                                    Nothing
+
+                            res ->
+                                res
+                    )
+                    Nothing
+    in
+        getType string
+            |> Maybe.map (\t -> ( t, getArity string ))

--- a/src/Helpers.elm
+++ b/src/Helpers.elm
@@ -460,6 +460,21 @@ applicationToList application =
             [ other ]
 
 
+{-| Change list of expressions into an application
+-}
+listToApplication : List Expression -> Expression
+listToApplication list =
+    case list of
+        [] ->
+            Debug.crash "Empty list to expression conversion"
+
+        [ one ] ->
+            one
+
+        left :: rest ->
+            Application left (listToApplication rest)
+
+
 {-| Change type application into a list of expressions
 -}
 typeApplicationToList : Type -> List Type

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -569,6 +569,28 @@ letIns =
         ]
 
 
+accessMacros : Test
+accessMacros =
+    describe "Access macros compile properly"
+        [ test "Update"
+            (\() ->
+                "test = updateIn .a (\\a -> a + 1)" |> has "update_in_([:a]).(fn a -> (a + 1) end)"
+            )
+        , test "Update5"
+            (\() ->
+                "test = updateIn5 .a .b .c .d .e (\\a -> a + 1) v" |> has "update_in_([:a, :b, :c, :d, :e]).(fn a -> (a + 1) end).(v())"
+            )
+        , test "Get"
+            (\() ->
+                "test = getIn3 .something .something .darkSide True v" |> has "get_in_([:something, :something, :dark_side]).(:true).(v())"
+            )
+        , test "Put"
+            (\() ->
+                "test = putIn4 .a .b .c .d 10 v" |> has "put_in_([:a, :b, :c, :d]).(10).(v())"
+            )
+        ]
+
+
 all : Test
 all =
     describe "All"
@@ -586,4 +608,5 @@ all =
         , doctests
         , fileImports
         , letIns
+        , accessMacros
         ]


### PR DESCRIPTION
Macros used to update nested structs type-safely