### PR TITLE
Corrected typo, set Compiler to 90%

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Elchemy uses Elm to typecheck your program. Although it is possible to use it wi
 # Maturity of the project
 
 - Parser - **99%** of Elm's syntax (see [elm-ast](https://github.com/Bogdanp/elm-ast/issues))
-- Compiler - **90%** (Sophisticated incremental compilation. No support for Windows yet though ([#287](https://github.com/wende/elchemy/issues287)) also big reliance on unix tools ([#288](https://github.com/wende/elchemy/issues/288))
+- Compiler - **90%** (Sophisticated incremental compilation. No support for Windows yet though ([#287](https://github.com/wende/elchemy/issues/287)) also big reliance on unix tools ([#288](https://github.com/wende/elchemy/issues/288))
 - Elchemy-core - **95%** ( Everything covered except side effects and JSON Decoders) 
 - Interop with Elixir - **90%** - Purity tests ([#162](https://github.com/wende/elchemy/issues/162)) and handling of macro-heavy libraries ([#276](https://github.com/wende/elchemy/issues/276)) to go 
 - Ideology - **70%** - We've got a pretty solid idea of where Elchemy is going 

--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ Elchemy uses Elm to typecheck your program. Although it is possible to use it wi
 # Maturity of the project
 
 - Parser - **99%** of Elm's syntax (see [elm-ast](https://github.com/Bogdanp/elm-ast/issues))
-- Compiler - **99%** (Sophisticated incremental compilation. No support for Windows yet though ([#287](https://github.com/wende/elchemy/issues/287)) also big reliance on unix tools ([#288](https://github.com/wende/elchemy/issues/288))
-- Elchemy-core - **95** ( Everything covered except side effects and JSON Decoders) 
+- Compiler - **90%** (Sophisticated incremental compilation. No support for Windows yet though ([#287](https://github.com/wende/elchemy/issues287)) also big reliance on unix tools ([#288](https://github.com/wende/elchemy/issues/288))
+- Elchemy-core - **95%** ( Everything covered except side effects and JSON Decoders) 
 - Interop with Elixir - **90%** - Purity tests ([#162](https://github.com/wende/elchemy/issues/162)) and handling of macro-heavy libraries ([#276](https://github.com/wende/elchemy/issues/276)) to go 
 - Ideology - **70%** - We've got a pretty solid idea of where Elchemy is going 
 - Documentation - **80%** - There are two tutorials and a complete Gitbook documentation. Few entrance level tutorials though


### PR DESCRIPTION
I added a percentage sign to the Elchemy-core support. 

So this also changes the percentage support for the compiler to 90% since no Windows support weights probably more as 1% in practically everybody's opinion.

Wonderful to see how this overview about your progress grows, I absolutely love it ^-^