### PR TITLE
Correct typo

### DIFF
--- a/roadmap/TYPE_ALIASES.md
+++ b/roadmap/TYPE_ALIASES.md
@@ -28,7 +28,7 @@ If a type alias represents a structure like
 ``` elm
 type alias Human = { name : String, age : Int }
 ```
-You can use the name of an alias as a function to quickly instatiate a struct
+You can use the name of an alias as a function to quickly instantiate a struct
 . For instance:
 
 ``` elm


### PR DESCRIPTION
There is no type alias with multiple fields, you might add one.
The default Elm way spells an error in Elchemy Live.
![Screenshot_20190701_093015](https://user-images.githubusercontent.com/6344099/60418320-ea759780-9be2-11e9-9505-4a5698ce12ee.png)
